### PR TITLE
Add glsl-constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "glsl-2d-primitives",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8,6 +8,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-aastep/-/glsl-aastep-1.0.1.tgz",
       "integrity": "sha1-7q8Wlh5HLJuLPZZdCAq47B1Ma7g="
+    },
+    "glsl-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glsl-constants/-/glsl-constants-1.0.0.tgz",
+      "integrity": "sha512-cC/sxTrHutIjeJlPiMLaHCCIkm2MaMgE2VmBjS5uiHzEOS3pCBFFpqWq2TGEhwKRYL73aHKuqHVWHp3ThnJd2A=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/ayamflow/glsl-2d-primitives#readme",
   "dependencies": {
-    "glsl-aastep": "^1.0.1"
+    "glsl-aastep": "^1.0.1",
+    "glsl-constants": "^1.0.0"
   }
 }

--- a/polygon.glsl
+++ b/polygon.glsl
@@ -1,6 +1,5 @@
-#define PI 3.14159265359
-#define TWO_PI 6.28318530718
-
+#pragma glslify: PI = require(glsl-constants/PI)
+#pragma glslify: TWO_PI = require(glsl-constants/TWO_PI)
 #pragma glslify: aastep = require(glsl-aastep)
 
 float polygon(vec2 st, float radius, float sides) {


### PR DESCRIPTION
Yo Flo, from my readings and understandings, using `const` over a `#define` macro would ensure:

- type safety
- the ability to restrict or redefine the const within a specific block

Also modules FTW.